### PR TITLE
Fix empty JSON response handling

### DIFF
--- a/client/src/components/admin-table.tsx
+++ b/client/src/components/admin-table.tsx
@@ -21,7 +21,8 @@ async function apiRequest(method: string, url: string, data?: any) {
     throw new Error("Network response was not ok");
   }
 
-  return response.json();
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
 }
 
 export default function AdminTable() {


### PR DESCRIPTION
## Summary
- handle empty JSON responses in admin table API helper

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6878d8b7d17c832f869ff36ba28e42fb