### PR TITLE
Fix empty JSON response handling

### DIFF
--- a/client/src/components/admin-table.tsx
+++ b/client/src/components/admin-table.tsx
@@ -8,21 +8,9 @@ import { Badge } from "@/components/ui/badge";
 import { Check, X, Search, ChevronLeft, ChevronRight } from "lucide-react";
 import { type Review } from "@shared/schema";
 import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
 import StarRating from "./star-rating";
 
-async function apiRequest(method: string, url: string, data?: any) {
-  const response = await fetch(url, {
-    method,
-    headers: data ? { "Content-Type": "application/json" } : {},
-    body: data ? JSON.stringify(data) : undefined,
-  });
-
-  if (!response.ok) {
-    throw new Error("Network response was not ok");
-  }
-
-  return response.json();
-}
 
 export default function AdminTable() {
   const [searchQuery, setSearchQuery] = useState("");


### PR DESCRIPTION
## Summary
- handle empty JSON responses in admin table API helper

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6878d8b7d17c832f869ff36ba28e42fb