### PR TITLE
Build and deploy service

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -133,32 +133,6 @@ export class DatabaseStorage implements IStorage {
     const result = await db.delete(reviews).where(eq(reviews.id, id));
     return result.rowCount > 0;
   }
-
-  async getReviewStats(): Promise<{
-    total: number;
-    pending: number;
-    approved: number;
-    rejected: number;
-    averageRating: number;
-  }> {
-    const allReviews = await this.getReviews();
-    
-    const stats = {
-      total: allReviews.length,
-      pending: allReviews.filter(r => r.status === "pending").length,
-      approved: allReviews.filter(r => r.status === "approved").length,
-      rejected: allReviews.filter(r => r.status === "rejected").length,
-      averageRating: 0,
-    };
-
-    if (stats.approved > 0) {
-      const approvedReviews = allReviews.filter(r => r.status === "approved");
-      const totalRating = approvedReviews.reduce((sum, r) => sum + r.rating, 0);
-      stats.averageRating = Math.round((totalRating / stats.approved) * 10) / 10;
-    }
-
-    return stats;
-  }
 }
 
 export const storage = new DatabaseStorage();


### PR DESCRIPTION
Remove duplicate `getReviewStats` method to resolve a build warning and ensure correct data format.

The `DatabaseStorage` class contained two `getReviewStats` methods. The method at line 137 was a duplicate that returned an incorrect data structure (e.g., `total` instead of `totalReviews`), which did not align with the `IStorage` interface or the data expected by the frontend components. Removing this redundant and incorrect method ensures consistency and resolves the "duplicate class member" warning.